### PR TITLE
A number of fixes for the audio module processing

### DIFF
--- a/components/iq2020/iq2020.h
+++ b/components/iq2020/iq2020.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #define IQ202BUFLEN 512
+#define IQ2020OUTBUFLEN 64
 #define FANCOUNT 4
 #define FAN_JETS1 0
 #define FAN_JETS2 1
@@ -285,7 +286,7 @@ protected:
 	// IQ2020 processing
 	int nextPossiblePacket();
 	unsigned char processingBuffer[IQ202BUFLEN];
-	unsigned char outboundBuffer[64];
+	unsigned char outboundBuffer[IQ2020OUTBUFLEN];
 	int processingBufferLen = 0;
 	void processRawIQ2020Data(unsigned char *data, int len);
 	int processIQ2020Command();


### PR DESCRIPTION
- Fixed "Receive buffer out of sync!" message by allowing 0x00 as a valid operation flag value
- Added better processing of the current state of the audio module. Now sets the audio power switch based on the value received from the audio module.
- Slight adjustment to the switchAction handling for audio power to ensure only 1 or 0 is sent.
- Extra: While troubleshooting the out of sync issue, noticed there was a potential for a buffer overflow in sendIQ2020Command. Added a guard.

From monitoring traffic, it appears the IQ2020 sends a message to the Audio Module with an operation flag of '0x00' instead of 0x40. This only happens when the audio module is off (or being turned off). The audio module processes the command anyway and responds with a 0x80 message.

@Ylianst I haven't dug much into the audio emulation code, you will likely want to run some regression tests to make sure I didn't break something... I also added some comments to help keep me on track.

You may want to limit `0x00` as only valid when used in conjunction with the audio module, since we don't know for certain what its used for, but I don't think there is much harm in leaving it as is.