### PR TITLE
Fix Time Protocol handling

### DIFF
--- a/DataViewer/DataViewerGtk/MainWindow.cs
+++ b/DataViewer/DataViewerGtk/MainWindow.cs
@@ -679,7 +679,7 @@ namespace DataViewer
                         int minutes = data[132];
                         int hours = data[133];
                         int day = data[134];
-                        int month = data[135] + 1;
+                        int month = data[135];
                         int year = data[136] + (data[137] << 8);
                         try
                         {
@@ -987,7 +987,7 @@ namespace DataViewer
             b[1] = (byte)n.Minute;
             b[2] = (byte)n.Hour;
             b[3] = (byte)n.Day;
-            b[4] = (byte)(n.Month - 1);
+            b[4] = (byte)(n.Month);
             b[5] = (byte)(n.Year & 0xFF);
             b[6] = (byte)(n.Year >> 8);
             SendPacket("01 1F 40 024C " + ConvertByteArrayToHexString(b, 0, 7));

--- a/DataViewer/DataViewerOSX/MainWindowController.cs
+++ b/DataViewer/DataViewerOSX/MainWindowController.cs
@@ -674,7 +674,7 @@ namespace DataViewerOSX
                             int minutes = data[132];
                             int hours = data[133];
                             int day = data[134];
-                            int month = data[135] + 1;
+                            int month = data[135];
                             int year = data[136] + (data[137] << 8);
                             try
                             {
@@ -1051,7 +1051,7 @@ namespace DataViewerOSX
             b[1] = (byte)n.Minute;
             b[2] = (byte)n.Hour;
             b[3] = (byte)n.Day;
-            b[4] = (byte)(n.Month - 1);
+            b[4] = (byte)(n.Month);
             b[5] = (byte)(n.Year & 0xFF);
             b[6] = (byte)(n.Year >> 8);
             SendPacket("01 1F 40 024C " + ConvertByteArrayToHexString(b, 0, 7));

--- a/DataViewer/DataViewerXC/DataViewer/ContentView.swift
+++ b/DataViewer/DataViewerXC/DataViewer/ContentView.swift
@@ -355,7 +355,7 @@ struct ContentView: View {
             UInt8(minute),
             UInt8(hour),
             UInt8(day),
-            UInt8(month - 1),  // Month is 0-based in the protocol
+            UInt8(month),
             UInt8(year & 0xFF),
             UInt8(year >> 8)
         ]

--- a/DataViewer/DataViewerXC/DataViewer/PacketProcessor.swift
+++ b/DataViewer/DataViewerXC/DataViewer/PacketProcessor.swift
@@ -118,7 +118,7 @@ class PacketProcessor: ObservableObject {
             let minutes = Int(bytes[132])
             let hours = Int(bytes[133])
             let day = Int(bytes[134])
-            let month = Int(bytes[135]) + 1
+            let month = Int(bytes[135])
             let year = Int(bytes[136]) + (Int(bytes[137]) << 8)
             
             if let date = createDate(year: year, month: month, day: day, hour: hours, minute: minutes, second: seconds) {
@@ -280,7 +280,7 @@ class PacketProcessor: ObservableObject {
             let minutes = Int(bytes[132])
             let hours = Int(bytes[133])
             let day = Int(bytes[134])
-            let month = Int(bytes[135]) + 1
+            let month = Int(bytes[135])
             let year = Int(bytes[136]) + (Int(bytes[137]) << 8)
             decode += String(format: "Time: %02d:%02d:%02d\n", hours, minutes, seconds)
             decode += String(format: "Date: %d-%d-%d\n", day, month, year)

--- a/DataViewer/MainForm.cs
+++ b/DataViewer/MainForm.cs
@@ -246,7 +246,7 @@ namespace DataViewer
                         int minutes = data[132];
                         int hours = data[133];
                         int day = data[134];
-                        int month = data[135] + 1;
+                        int month = data[135];
                         int year = data[136] + (data[137] << 8);
                         try { addDecodedData("Time", new DateTime(year, month, day, hours, minutes, seconds).ToString()); } catch (Exception) { }
 
@@ -698,7 +698,7 @@ namespace DataViewer
             b[1] = (byte)n.Minute;
             b[2] = (byte)n.Hour;
             b[3] = (byte)n.Day;
-            b[4] = (byte)(n.Month - 1);
+            b[4] = (byte)(n.Month);
             b[5] = (byte)(n.Year & 0xFF);
             b[6] = (byte)(n.Year >> 8);
             SendPacket("01 1F 40 024C " + ConvertByteArrayToHexString(b , 0 , 7));

--- a/components/iq2020-dev/iq2020.cpp
+++ b/components/iq2020-dev/iq2020.cpp
@@ -977,7 +977,7 @@ int IQ2020Component::processIQ2020Command() {
 
 void IQ2020Component::setTime(int hour, int minute, int second, int year, int month, int day) {
 	ESP_LOGD(TAG, "setTime, time(h:m:s) = %d:%d:%d, date(y:m:d) = %d:%d:%d", hour, minute, second, year, month, day);
-	unsigned char setTimeCmd[] = { 0x02, 0x4C, (unsigned char)second, (unsigned char)minute, (unsigned char)hour, (unsigned char)day, (unsigned char)(month - 1), (unsigned char)(year & 0xFF), (unsigned char)(year >> 8) };
+	unsigned char setTimeCmd[] = { 0x02, 0x4C, (unsigned char)second, (unsigned char)minute, (unsigned char)hour, (unsigned char)day, (unsigned char)month, (unsigned char)(year & 0xFF), (unsigned char)(year >> 8) };
 	sendIQ2020Command(0x01, 0x1F, 0x40, setTimeCmd, 9);
 }
 

--- a/components/iq2020-legacy/iq2020.cpp
+++ b/components/iq2020-legacy/iq2020.cpp
@@ -925,7 +925,7 @@ int IQ2020Component::processIQ2020Command() {
 
 void IQ2020Component::setTime(int hour, int minute, int second, int year, int month, int day) {
 	ESP_LOGD(TAG, "setTime, time(h:m:s) = %d:%d:%d, date(y:m:d) = %d:%d:%d", hour, minute, second, year, month, day);
-	unsigned char setTimeCmd[] = { (unsigned char)second, (unsigned char)minute, (unsigned char)hour, (unsigned char)day, (unsigned char)(month - 1), (unsigned char)(year & 0xFF), (unsigned char)(year >> 8) };
+	unsigned char setTimeCmd[] = { (unsigned char)second, (unsigned char)minute, (unsigned char)hour, (unsigned char)day, (unsigned char)month, (unsigned char)(year & 0xFF), (unsigned char)(year >> 8) };
 	sendIQ2020Command(0x01, 0x1F, 0x40, setTimeCmd, 7);
 }
 

--- a/components/iq2020/iq2020.cpp
+++ b/components/iq2020/iq2020.cpp
@@ -897,7 +897,7 @@ int IQ2020Component::processIQ2020Command() {
 				int minutes = processingBuffer[132];
 				int hours = processingBuffer[133];
 				int day = processingBuffer[134];
-				int month = processingBuffer[135] + 1;
+				int month = processingBuffer[135];
 				int year = processingBuffer[136] + (processingBuffer[137] << 8);
 
 				// Format and publish RTC datetime in ISO 8601 format
@@ -977,7 +977,7 @@ int IQ2020Component::processIQ2020Command() {
 
 void IQ2020Component::setTime(int hour, int minute, int second, int year, int month, int day) {
 	ESP_LOGD(TAG, "setTime, time(h:m:s) = %d:%d:%d, date(y:m:d) = %d:%d:%d", hour, minute, second, year, month, day);
-	unsigned char setTimeCmd[] = { 0x02, 0x4C, (unsigned char)second, (unsigned char)minute, (unsigned char)hour, (unsigned char)day, (unsigned char)(month - 1), (unsigned char)(year & 0xFF), (unsigned char)(year >> 8) };
+	unsigned char setTimeCmd[] = { 0x02, 0x4C, (unsigned char)second, (unsigned char)minute, (unsigned char)hour, (unsigned char)day, (unsigned char)month, (unsigned char)(year & 0xFF), (unsigned char)(year >> 8) };
 	sendIQ2020Command(0x01, 0x1F, 0x40, setTimeCmd, 9);
 }
 

--- a/documentation/protocol.md
+++ b/documentation/protocol.md
@@ -409,7 +409,7 @@ F30E              - Power L2 wattage - Water heater wattage (Big-Endian)
 6A                - PCB temperature
 6F                - Peripheral Current
 00080800          - Real-Time-Clock SS:MM:HH Seconds (0 to 59), Minutes (0 to 59), Hours (0 to 24).
-1300D407          - Real-Time-Clock DD:MM:YYYY Days (1 to 31), Month (0 to 11), Year (2 byte Big-Endian).
+1300D407          - Real-Time-Clock DD:MM:YYYY Days (1 to 31), Month (1 to 12), Year (2 byte Big-Endian).
 01                - Real-Time-Clock Status
 ```
 
@@ -505,7 +505,7 @@ Get Current Time
                  SSMMHHDDMMYYYY
 Encoded as:
 SS:MM:HH Seconds (0 to 59), Minutes (0 to 59), Hours (0 to 24).
-DD:MM:YYYY Days (1 to 31), Month (0 to 11), Year (2 byte Big-Endian).
+DD:MM:YYYY Days (1 to 31), Month (1 to 12), Year (2 byte Big-Endian).
 ```
 
 Set Current Time


### PR DESCRIPTION
The IQ2020 seems to handle the month using the range 1-12. The current code had a lot of special casing to try to remap this (unsuccessfully) to 0-11 for the timeinfo struct to pass to mktime to calculate the unix timestamp from the RTC.

Update the protocol docs, components, and debug applications to use the range 1-12 and only remap to 0-11 when actually calling mktime.

Fixes #78.