### PR TITLE
Fix garbage percentage value when jets are off

### DIFF
--- a/components/iq2020/fan/iq2020_fan.cpp
+++ b/components/iq2020/fan/iq2020_fan.cpp
@@ -42,7 +42,7 @@ namespace iq2020_fan {
 	void IQ2020Fan::updateState(int s) {
 		ESP_LOGCONFIG(TAG, "IQ2020 fan %d update. State: %d", fan_id, s);
 		switch (s) {
-			case 0: { state = false; break; } // OFF
+			case 0: { state = false; speed = 0; break; } // OFF
 			case 1: { state = true; speed = 1; break; } // MEDIUM
 			case 2: { state = true; speed = (fan_speeds == 2) ? 2 : 1; break; } // FULL
 		}


### PR DESCRIPTION
**Description:**
I saw totally bogus values like `107379211900%` jet speed from the integration, even when pumps were clearly not running. I think this also confused the UI as in this case it showed on, but I couldn't switch it off in the UI to match reality. Didn't always happen, but happened enough where this was pretty annoying.

**Root Cause:**
Maybe :) When jets are turned off from Home Assistant, `control()` seems to unconditionally dereference `call.get_speed()` (an optional that may be empty when turning off), which likely is sometimes writing garbage data to speed. Then since `updateState(0)` `case 0` only set `state = false` without resetting `speed`, I think is how the garbage value persisted. 

**Fix:**
Added `speed = 0` to the `case 0` (OFF) in `updateState()`, ensuring any stale/corrupted value is always cleared when the jets are off.

**Testing:**
Confirmed on a Hot Spring Aria + M5Stack. Jets now correctly report off at 0% when not running. Running stable for ~1 week.

Fixes #76