### PR TITLE
fix: min temp 26c, was 26.5c

### DIFF
--- a/components/iq2020/climate/iq2020_climate.cpp
+++ b/components/iq2020/climate/iq2020_climate.cpp
@@ -56,12 +56,12 @@ namespace iq2020_climate {
 		traits.add_feature_flags(climate::CLIMATE_SUPPORTS_ACTION);
 
 		if (celsius) { // Celsius setup
-			traits.set_visual_min_temperature(26.5);
+			traits.set_visual_min_temperature(26);
 			traits.set_visual_max_temperature(40);
 			traits.set_visual_target_temperature_step(0.5);
 			traits.set_visual_current_temperature_step(0.5);
 		} else { // Fahrenheit setup
-			traits.set_visual_min_temperature(26.5); // fahrenheit_to_celsius(80)
+			traits.set_visual_min_temperature(26); // fahrenheit_to_celsius(80)
 			traits.set_visual_max_temperature(40); // fahrenheit_to_celsius(104)
 			traits.set_visual_target_temperature_step(1);
 			traits.set_visual_current_temperature_step(1);


### PR DESCRIPTION
Changes minimum temperature to 26c, instead of 26.5c. 
At least on my hottub 26 is the real minimum temp.