### PR TITLE
Add new salt water sensors/commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
+__pycache__/
+*.pyc
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/components/iq2020/button/__init__.py
+++ b/components/iq2020/button/__init__.py
@@ -1,0 +1,22 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import button
+from esphome.const import CONF_ID
+
+from .. import ns
+
+CONF_BUTTON_DATAPOINT = "datapoint"
+
+iq2020_button_ns = cg.esphome_ns.namespace('iq2020_button')
+IQ2020Button = iq2020_button_ns.class_('IQ2020Button', button.Button, cg.Component)
+
+CONFIG_SCHEMA = button.button_schema(IQ2020Button).extend({
+    cv.GenerateID(): cv.declare_id(IQ2020Button),
+    cv.Required(CONF_BUTTON_DATAPOINT): cv.positive_int,
+}).extend(cv.COMPONENT_SCHEMA)
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await button.register_button(var, config)
+    cg.add(var.set_button_id(config[CONF_BUTTON_DATAPOINT]))

--- a/components/iq2020/button/iq2020_button.cpp
+++ b/components/iq2020/button/iq2020_button.cpp
@@ -1,0 +1,30 @@
+#include "esphome/core/log.h"
+#include "iq2020_button.h"
+#include "../iq2020.h"
+
+extern IQ2020Component *g_iq2020_main;
+extern esphome::iq2020_button::IQ2020Button *g_iq2020_button[BUTTONCOUNT];
+
+namespace esphome {
+namespace iq2020_button {
+
+static const char *TAG = "iq2020.button";
+
+void IQ2020Button::setup() {
+  if (button_id < BUTTONCOUNT) {
+    g_iq2020_button[button_id] = this;
+  }
+}
+
+void IQ2020Button::press_action() {
+  ESP_LOGD(TAG, "Button:%d press", button_id);
+  if (g_iq2020_main != nullptr) {
+    g_iq2020_main->buttonAction(button_id);
+  }
+}
+
+void IQ2020Button::dump_config() {
+}
+
+}  // namespace iq2020_button
+}  // namespace esphome

--- a/components/iq2020/button/iq2020_button.h
+++ b/components/iq2020/button/iq2020_button.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/button/button.h"
+
+namespace esphome {
+namespace iq2020_button {
+
+class IQ2020Button : public button::Button, public Component {
+public:
+  void setup() override;
+  void dump_config() override;
+  void set_button_id(unsigned int id) { this->button_id = id; }
+
+protected:
+  void press_action() override;
+  unsigned int button_id;
+};
+
+}  // namespace iq2020_button
+}  // namespace esphome

--- a/components/iq2020/iq2020.cpp
+++ b/components/iq2020/iq2020.cpp
@@ -1,6 +1,9 @@
 #include "iq2020.h"
 #include "fan/iq2020_fan.h"
 #include "switch/iq2020_switch.h"
+#ifdef USE_BUTTON
+#include "button/iq2020_button.h"
+#endif
 #ifdef USE_SELECT
 #include "select/iq2020_select.h"
 #endif
@@ -35,6 +38,9 @@ esphome::iq2020_fan::IQ2020Fan* g_iq2020_fan[FANCOUNT];
 #ifdef USE_NUMBER
 esphome::iq2020_number::IQ2020Number* g_iq2020_number[NUMBERCOUNT];
 #endif
+#ifdef USE_BUTTON
+esphome::iq2020_button::IQ2020Button* g_iq2020_button[BUTTONCOUNT];
+#endif
 esphome::iq2020_climate::IQ2020Climate* g_iq2020_climate = NULL;
 
 using namespace esphome;
@@ -43,6 +49,13 @@ float fahrenheit_to_celsius(float f) { return (f - 32) * 5 / 9; }
 float celsius_to_fahrenheit(float c) { return c * 9 / 5 + 32; }
 int readCounter(unsigned char* data, int offset) { return (data[offset]) + (data[offset + 1] << 8) + (data[offset + 2] << 16) + (data[offset + 3] << 24); }
 int readCounterEx(unsigned char* data, int offset) { return (data[offset] << 24) + (data[offset + 1] << 16) + (data[offset + 2] << 8) + (data[offset + 3]); }
+static const char *salt_level_friendly_text(int salt_level) {
+	if (salt_level <= 24) return "red-low";
+	if (salt_level <= 36) return "yellow-low";
+	if (salt_level <= 84) return "green";
+	if (salt_level <= 96) return "yellow-high";
+	return "red-high";
+}
 
 void IQ2020Component::setup() {
 	for (int i = 0; i < SWITCHCOUNT; i++) { switch_state[i] = switch_pending[i] = NOT_SET; }
@@ -494,8 +507,9 @@ int IQ2020Component::processIQ2020Command() {
 	if (((processingBuffer[1] == 0x24) || (processingBuffer[1] == 0x29)) && (processingBuffer[2] == 0x01) && (processingBuffer[4] == 0x40) && (cmdlen == 21) && (processingBuffer[5] == 0x1E) && (processingBuffer[6] == 0x01)) {
 		// This is a command from IQ2020 to the Salt System
 		//ESP_LOGD(TAG, "Salt REQ Data, len=%d, cmd=%02x%02x", cmdlen, processingBuffer[5], processingBuffer[6]);
+		salt_module_address = processingBuffer[1];
 #ifdef USE_NUMBER
-		if (processingBuffer[7] <= 10) { setNumberState(NUMBER_SALT_POWER, processingBuffer[7]); }
+		if (processingBuffer[7] >= 1 && processingBuffer[7] <= 10) { setNumberState(NUMBER_SALT_POWER, processingBuffer[7]); }
 #endif
 
 #ifdef USE_BINARY_SENSOR
@@ -507,7 +521,7 @@ int IQ2020Component::processIQ2020Command() {
 
 		// ACE emulation
 		if (ace_emulation_ && (processingBuffer[1] == 0x24)) {
-			if (processingBuffer[7] <= 10) {
+			if (processingBuffer[7] >= 1 && processingBuffer[7] <= 10) {
 				salt_power = processingBuffer[7];
 #ifdef USE_NUMBER
 				setNumberState(NUMBER_SALT_POWER, salt_power);
@@ -531,7 +545,7 @@ int IQ2020Component::processIQ2020Command() {
 			sendIQ2020Command(0x01, 0x24, 0x80, cmd, sizeof(cmd));
 		}
 		else if (freshwater_emulation_ && (processingBuffer[1] == 0x29)) {
-			if (processingBuffer[7] <= 10) {
+			if (processingBuffer[7] >= 1 && processingBuffer[7] <= 10) {
 				salt_power = processingBuffer[7];
 #ifdef USE_NUMBER
 				setNumberState(NUMBER_SALT_POWER, salt_power);
@@ -547,19 +561,47 @@ int IQ2020Component::processIQ2020Command() {
 	if ((processingBuffer[1] == 0x01) && ((processingBuffer[2] == 0x24) || (processingBuffer[2] == 0x29)) && (processingBuffer[4] == 0x80) && (cmdlen == 21) && (processingBuffer[5] == 0x1E) && (processingBuffer[6] == 0x01)) {
 		// This is a reply command from the Salt System to the IQ2020
 		//ESP_LOGD(TAG, "Salt RSP Data, len=%d, cmd=%02x%02x, power=%d", cmdlen, processingBuffer[5], processingBuffer[6], processingBuffer[7]);
-		if ((processingBuffer[7] <= 10) && (salt_power != processingBuffer[7])) {
+		if ((processingBuffer[2] == 0x24) || (processingBuffer[2] == 0x29)) {
+			salt_module_address = processingBuffer[2];
+		}
+		if ((processingBuffer[7] >= 1 && processingBuffer[7] <= 10) && (salt_power != processingBuffer[7])) {
 			salt_power = processingBuffer[7];
 #ifdef USE_NUMBER
 			setNumberState(NUMBER_SALT_POWER, salt_power);
 #endif
 		}
 		if (salt_content != processingBuffer[9]) {
-			salt_content = processingBuffer[9] >> 4;
+			salt_content = processingBuffer[9];
 #ifdef USE_SENSOR
 			if (this->salt_content_sensor_) this->salt_content_sensor_->publish_state((float)salt_content);
 #endif
+#ifdef USE_TEXT_SENSOR
+			if (this->salt_level_friendly_sensor_) this->salt_level_friendly_sensor_->publish_state(salt_level_friendly_text(salt_content));
+#endif
 		}
-		setSwitchState(SWITCH_SALT_BOOST, (processingBuffer[12] & 0x04) != 0);
+#ifdef USE_SENSOR
+		if (this->salt_cartridge_age_days_sensor_) this->salt_cartridge_age_days_sensor_->publish_state((float) processingBuffer[8]);
+		if (this->salt_generation_hours_sensor_) this->salt_generation_hours_sensor_->publish_state((float) processingBuffer[15]);
+		if (this->salt_error_code_sensor_) {
+			const uint16_t salt_error_code = ((uint16_t) processingBuffer[13] << 8) | processingBuffer[14];
+			this->salt_error_code_sensor_->publish_state((float) salt_error_code);
+		}
+#endif
+		// Salt module panel mode is encoded by MF (byte 8), with 0x07 indicating boost mode.
+		setSwitchState(SWITCH_SALT_BOOST, processingBuffer[12] == 0x07);
+#ifdef USE_TEXT_SENSOR
+		if (this->salt_module_status_sensor_) {
+			if ((processingBuffer[19] & 0x40) != 0) {
+				this->salt_module_status_sensor_->publish_state("idle");
+			}
+			else if ((processingBuffer[19] & 0x80) != 0) {
+				this->salt_module_status_sensor_->publish_state("generating_chlorine");
+			}
+			else {
+				this->salt_module_status_sensor_->publish_state("cleaning_cartridge");
+			}
+		}
+#endif
 	}
 
 	// IQ2020 -> SPA connection kit Response
@@ -1108,10 +1150,17 @@ void IQ2020Component::switchAction(unsigned int switchid, int state) {
 			switch_state[switchid] = switch_pending[switchid] = state;
 		}
 		else
-		{   // Control a real ACE module
+		{   // Control a real salt module (legacy ACE or freshwater salt)
 			switch_pending[switchid] = state; // 0 = OFF, 1 = ON
-			unsigned char cmd[] = { 0x1E, 0x02, 0x03, (unsigned char)(state ? 0x08 : 0x00), 0x00 };
-			sendIQ2020Command(0x01, 0x1F, 0x40, cmd, sizeof(cmd));
+			if (salt_module_address == 0x29) {
+				unsigned char cmd[] = { 0x1E, 0x01, 0xFF, 0x02, 0xFF, 0xFF, (unsigned char)(state ? 0x01 : 0x02), 0x00, 0xFF, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+				sendIQ2020Command(0x29, 0x01, 0x40, cmd, sizeof(cmd));
+				next_poll = ::millis() + 100;
+			}
+			else {
+				unsigned char cmd[] = { 0x1E, 0x02, 0x03, (unsigned char)(state ? 0x08 : 0x00), 0x00 };
+				sendIQ2020Command(0x01, 0x1F, 0x40, cmd, sizeof(cmd));
+			}
 		}
 		break;
 	}
@@ -1245,9 +1294,16 @@ void IQ2020Component::numberAction(unsigned int numberid, int value) {
 	}
 	case NUMBER_SALT_POWER:
 	{
+		if (value < 1 || value > 10) return;
 		number_pending[NUMBER_SALT_POWER] = value;
-		unsigned char cmd[] = { 0x1E, 0x02, 0x01, (unsigned char)value, 0x00 };
-		sendIQ2020Command(0x01, 0x1F, 0x40, cmd, sizeof(cmd)); // Change salt power
+		if (salt_module_address == 0x29) {
+			unsigned char cmd[] = { 0x1E, 0x01, (unsigned char)value, 0x02, 0xFF, 0xFF, 0xFF, 0x00, 0xFF, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+			sendIQ2020Command(0x29, 0x01, 0x40, cmd, sizeof(cmd)); // Freshwater salt command
+		}
+		else {
+			unsigned char cmd[] = { 0x1E, 0x02, 0x01, (unsigned char)value, 0x00 };
+			sendIQ2020Command(0x01, 0x1F, 0x40, cmd, sizeof(cmd)); // Legacy ACE-style command
+		}
 		break;
 	}
 	case NUMBER_SALT_STATUS:
@@ -1289,6 +1345,27 @@ void IQ2020Component::numberAction(unsigned int numberid, int value) {
 	// If the command does not get confirmed, setup to try again
 	next_retry_count += SWITCH_RETRY_COUNT;
 	next_retry = ::millis() + SWITCH_RETRY_TIME;
+}
+#endif
+
+#ifdef USE_BUTTON
+void IQ2020Component::buttonAction(unsigned int buttonid) {
+	unsigned char cmd[] = { 0x1E, 0x01, 0xFF, 0x02, 0xFF, 0xFF, 0xFF, 0x00, 0xFF, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+	switch (buttonid) {
+	case BUTTON_SALT_TEST:
+		cmd[11] = 0x01; // FF 01 FF 01
+		sendIQ2020Command(0x29, 0x01, 0x40, cmd, sizeof(cmd));
+		break;
+	case BUTTON_RESET_CARTRIDGE:
+		cmd[8] = 0x02;  // 02 01 02 FF
+		cmd[10] = 0x02;
+		cmd[11] = 0xFF;
+		sendIQ2020Command(0x29, 0x01, 0x40, cmd, sizeof(cmd));
+		break;
+	default:
+		return;
+	}
+	next_poll = ::millis() + 100;
 }
 #endif
 

--- a/components/iq2020/iq2020.cpp
+++ b/components/iq2020/iq2020.cpp
@@ -592,8 +592,13 @@ int IQ2020Component::processIQ2020Command() {
 			this->salt_error_code_sensor_->publish_state((float) salt_error_code);
 		}
 #endif
-		// Salt module panel mode is encoded by MF (byte 8), with 0x07 indicating boost mode.
-		setSwitchState(SWITCH_SALT_BOOST, processingBuffer[12] == 0x07);
+		// Preserve legacy ACE boost bit behavior (0x24) and freshwater MF-based behavior (0x29).
+		if (salt_module_address == 0x24) {
+			setSwitchState(SWITCH_SALT_BOOST, (processingBuffer[12] & 0x04) != 0);
+		}
+		else {
+			setSwitchState(SWITCH_SALT_BOOST, processingBuffer[12] == 0x07);
+		}
 #ifdef USE_TEXT_SENSOR
 		if (this->salt_module_status_sensor_) {
 			if ((processingBuffer[19] & 0x40) != 0) {

--- a/components/iq2020/iq2020.cpp
+++ b/components/iq2020/iq2020.cpp
@@ -570,8 +570,13 @@ int IQ2020Component::processIQ2020Command() {
 			setNumberState(NUMBER_SALT_POWER, salt_power);
 #endif
 		}
-		if (salt_content != processingBuffer[9]) {
-			salt_content = processingBuffer[9];
+		int decoded_salt_content = processingBuffer[9];
+		// Preserve legacy ACE behavior (0x24) while using freshwater salt decoding for 0x29.
+		if (salt_module_address == 0x24) {
+			decoded_salt_content = processingBuffer[9] >> 4;
+		}
+		if (salt_content != decoded_salt_content) {
+			salt_content = decoded_salt_content;
 #ifdef USE_SENSOR
 			if (this->salt_content_sensor_) this->salt_content_sensor_->publish_state((float)salt_content);
 #endif

--- a/components/iq2020/iq2020.h
+++ b/components/iq2020/iq2020.h
@@ -13,6 +13,9 @@
 #ifdef USE_TEXT_SENSOR
 #include "esphome/components/text_sensor/text_sensor.h"
 #endif
+#ifdef USE_BUTTON
+#include "esphome/components/button/button.h"
+#endif
 
 #include <memory>
 #include <string>
@@ -61,6 +64,9 @@
 #define NUMBER_LIGHTS2_INTENSITY 8     // Bartop lights intensity (0 to 5)
 #define NUMBER_LIGHTS3_INTENSITY 9     // Pillow lights intensity (0 to 5)
 #define NUMBER_LIGHTS4_INTENSITY 10    // Exterior lights intensity (0 to 5)
+#define BUTTONCOUNT 2
+#define BUTTON_SALT_TEST 0
+#define BUTTON_RESET_CARTRIDGE 1
 #define NOT_SET -127
 
 class IQ2020Component : public esphome::Component, public esphome::api::CustomAPIDevice {
@@ -137,10 +143,18 @@ public:
 	void set_iq_ph_sensor(esphome::sensor::Sensor *sensor) { this->iq_ph_sensor_ = sensor; }
 	void set_iq_hoursleft_sensor(esphome::sensor::Sensor *sensor) { this->iq_hoursleft_sensor_ = sensor; }
 	void set_rtc_timestamp_sensor(esphome::sensor::Sensor *sensor) { this->rtc_timestamp_sensor_ = sensor; }
+	void set_salt_cartridge_age_days_sensor(esphome::sensor::Sensor *sensor) { this->salt_cartridge_age_days_sensor_ = sensor; }
+	void set_salt_generation_hours_sensor(esphome::sensor::Sensor *sensor) { this->salt_generation_hours_sensor_ = sensor; }
+	void set_salt_error_code_sensor(esphome::sensor::Sensor *sensor) { this->salt_error_code_sensor_ = sensor; }
 #endif
 #ifdef USE_TEXT_SENSOR
 	void set_version_sensor(esphome::text_sensor::TextSensor *text) { this->version_sensor_ = text; }
 	void set_rtc_datetime_sensor(esphome::text_sensor::TextSensor *text) { this->rtc_datetime_sensor_ = text; }
+	void set_salt_module_status_sensor(esphome::text_sensor::TextSensor *text) { this->salt_module_status_sensor_ = text; }
+	void set_salt_level_friendly_sensor(esphome::text_sensor::TextSensor *text) { this->salt_level_friendly_sensor_ = text; }
+#endif
+#ifdef USE_BUTTON
+	void buttonAction(unsigned int buttonid);
 #endif
 
 	void setup() override;
@@ -259,10 +273,15 @@ protected:
 	esphome::sensor::Sensor *iq_ph_sensor_;
 	esphome::sensor::Sensor *iq_hoursleft_sensor_;
 	esphome::sensor::Sensor *rtc_timestamp_sensor_;
+	esphome::sensor::Sensor *salt_cartridge_age_days_sensor_;
+	esphome::sensor::Sensor *salt_generation_hours_sensor_;
+	esphome::sensor::Sensor *salt_error_code_sensor_;
 #endif
 #ifdef USE_TEXT_SENSOR
 	esphome::text_sensor::TextSensor *version_sensor_;
 	esphome::text_sensor::TextSensor *rtc_datetime_sensor_;
+	esphome::text_sensor::TextSensor *salt_module_status_sensor_;
+	esphome::text_sensor::TextSensor *salt_level_friendly_sensor_;
 #endif
 
 	std::unique_ptr<uint8_t[]> buf_{};
@@ -299,6 +318,7 @@ protected:
 	int next_retry_count = 0;
 	int salt_power = NOT_SET; // This is polled too frequently to send to HA each time.
 	int salt_content = NOT_SET; // This is polled too frequently to send to HA each time.
+	unsigned char salt_module_address = 0x29; // Last seen salt module address (0x24 legacy ACE, 0x29 freshwater salt).
 	std::string audio_song_title;
 	std::string audio_artist_name;
 

--- a/components/iq2020/number/iq2020_number.cpp
+++ b/components/iq2020/number/iq2020_number.cpp
@@ -37,7 +37,7 @@ namespace iq2020_number {
 			this->traits.set_max_value(11);
 			break;
 		case NUMBER_SALT_POWER:
-			this->traits.set_min_value(0);
+			this->traits.set_min_value(1);
 			this->traits.set_max_value(10);
 			break;
 		case NUMBER_SALT_STATUS:

--- a/components/iq2020/sensor.py
+++ b/components/iq2020/sensor.py
@@ -43,6 +43,9 @@ CONF_SENSOR_JETS2_LOW_RUNTIME = "jet2_low_total_runtime"
 CONF_SENSOR_POWER_ON_COUNTER = "power_on_counter"
 CONF_SENSOR_SALT_POWER = "salt_power"
 CONF_SENSOR_SALT_CONTENT = "salt_content"
+CONF_SENSOR_SALT_CARTRIDGE_AGE_DAYS = "salt_cartridge_age_days"
+CONF_SENSOR_SALT_GENERATION_HOURS = "salt_generation_hours"
+CONF_SENSOR_SALT_ERROR_CODE = "salt_error_code"
 CONF_SENSOR_CONNECTION_COUNT = "connection_count"
 CONF_SENSOR_VOLTAGE_L1 = "voltage_l1"
 CONF_SENSOR_VOLTAGE_HEATER = "voltage_heater"
@@ -204,6 +207,21 @@ CONFIG_SCHEMA = cv.Schema(
             accuracy_decimals=0,
             state_class=STATE_CLASS_MEASUREMENT,
             icon=ICON_GAUGE
+        ),
+        cv.Optional(CONF_SENSOR_SALT_CARTRIDGE_AGE_DAYS): sensor.sensor_schema(
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+            icon=ICON_TIMER
+        ),
+        cv.Optional(CONF_SENSOR_SALT_GENERATION_HOURS): sensor.sensor_schema(
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+            icon=ICON_TIMER
+        ),
+        cv.Optional(CONF_SENSOR_SALT_ERROR_CODE): sensor.sensor_schema(
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+            icon="mdi:alert-circle-outline"
         ),
         cv.Optional(CONF_SENSOR_VOLTAGE_L1): sensor.sensor_schema(
             unit_of_measurement=UNIT_VOLT,
@@ -439,6 +457,15 @@ async def to_code(config):
     if CONF_SENSOR_SALT_CONTENT in config:
         sens = await sensor.new_sensor(config[CONF_SENSOR_SALT_CONTENT])
         cg.add(server.set_salt_content_sensor(sens))
+    if CONF_SENSOR_SALT_CARTRIDGE_AGE_DAYS in config:
+        sens = await sensor.new_sensor(config[CONF_SENSOR_SALT_CARTRIDGE_AGE_DAYS])
+        cg.add(server.set_salt_cartridge_age_days_sensor(sens))
+    if CONF_SENSOR_SALT_GENERATION_HOURS in config:
+        sens = await sensor.new_sensor(config[CONF_SENSOR_SALT_GENERATION_HOURS])
+        cg.add(server.set_salt_generation_hours_sensor(sens))
+    if CONF_SENSOR_SALT_ERROR_CODE in config:
+        sens = await sensor.new_sensor(config[CONF_SENSOR_SALT_ERROR_CODE])
+        cg.add(server.set_salt_error_code_sensor(sens))
 
     if CONF_SENSOR_VOLTAGE_L1 in config:
         sens = await sensor.new_sensor(config[CONF_SENSOR_VOLTAGE_L1])

--- a/components/iq2020/text_sensor.py
+++ b/components/iq2020/text_sensor.py
@@ -6,6 +6,8 @@ from . import ns, IQ2020Component
 CONF_IQ2020_SERVER = "iq2020_server"
 CONF_SENSOR_VERSION = "versionstr"
 CONF_SENSOR_RTC_DATETIME = "rtc_datetime"
+CONF_SENSOR_SALT_MODULE_STATUS = "salt_module_status"
+CONF_SENSOR_SALT_LEVEL_FRIENDLY = "salt_level_friendly"
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -15,7 +17,13 @@ CONFIG_SCHEMA = cv.Schema(
         ),
         cv.Optional(CONF_SENSOR_RTC_DATETIME): text_sensor.text_sensor_schema(
             icon="mdi:clock-outline"
-        )
+        ),
+        cv.Optional(CONF_SENSOR_SALT_MODULE_STATUS): text_sensor.text_sensor_schema(
+            icon="mdi:water-check"
+        ),
+        cv.Optional(CONF_SENSOR_SALT_LEVEL_FRIENDLY): text_sensor.text_sensor_schema(
+            icon="mdi:water-opacity"
+        ),
     }
 )
 
@@ -29,3 +37,11 @@ async def to_code(config):
     if CONF_SENSOR_RTC_DATETIME in config:
         sens = await text_sensor.new_text_sensor(config[CONF_SENSOR_RTC_DATETIME])
         cg.add(server.set_rtc_datetime_sensor(sens))
+
+    if CONF_SENSOR_SALT_MODULE_STATUS in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_SENSOR_SALT_MODULE_STATUS])
+        cg.add(server.set_salt_module_status_sensor(sens))
+
+    if CONF_SENSOR_SALT_LEVEL_FRIENDLY in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_SENSOR_SALT_LEVEL_FRIENDLY])
+        cg.add(server.set_salt_level_friendly_sensor(sens))

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -201,9 +201,11 @@ button:
   - platform: restart
     name: "ESP Restart"
   - platform: iq2020
+    # Freshwater Salt only
     name: Salt Test
     datapoint: 0
   - platform: iq2020
+    # Freshwater Salt only
     name: Reset Salt Cartridge
     datapoint: 1
     
@@ -211,6 +213,7 @@ binary_sensor:
   - platform: status
     name: ESP Status
   - platform: iq2020
+    # ACE/Freshwater Salt
     salt_level_confirmed:
       name: Salt Level Confirmed
 
@@ -227,12 +230,16 @@ sensor:
       name: Heater Outlet
     pcb_${celcius_farenheit}_temperature:
       name: Controller Temperature
+    # ACE/Freshwater Salt
     salt_content:
       name: Salt Level
+    # Freshwater Salt only
     salt_cartridge_age_days:
       name: Salt Cartridge Age (Days)
+    # Freshwater Salt only
     salt_generation_hours:
       name: Salt Generation Hours
+    # Freshwater Salt only
     salt_error_code:
       name: Salt Error Code
 
@@ -373,6 +380,7 @@ number:
     datapoint: 4
   #jacuzzi salt control
   - platform: iq2020
+    # ACE/Freshwater Salt
     id: salt_power
     name: Salt System Power
     datapoint: 5
@@ -464,8 +472,10 @@ text_sensor:
   - platform: iq2020
     versionstr:
       name: Version
+    # Freshwater Salt only
     salt_module_status:
       name: Salt Module Status
+    # Freshwater Salt only
     salt_level_friendly:
       name: Salt Level Friendly
   - platform: template
@@ -610,4 +620,3 @@ text_sensor:
 ![image](https://github.com/Ylianst/ESP-IQ2020/assets/1319013/c5b25972-1409-4477-964a-1dc21645407e)
 
 ![image](https://github.com/Ylianst/ESP-IQ2020/assets/1319013/1561b409-8329-48f7-a581-f6841265b1d5)
-

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -200,6 +200,12 @@ time:
 button:
   - platform: restart
     name: "ESP Restart"
+  - platform: iq2020
+    name: Salt Test
+    datapoint: 0
+  - platform: iq2020
+    name: Reset Salt Cartridge
+    datapoint: 1
     
 binary_sensor:    
   - platform: status
@@ -222,7 +228,13 @@ sensor:
     pcb_${celcius_farenheit}_temperature:
       name: Controller Temperature
     salt_content:
-      name: Salt Content
+      name: Salt Level
+    salt_cartridge_age_days:
+      name: Salt Cartridge Age (Days)
+    salt_generation_hours:
+      name: Salt Generation Hours
+    salt_error_code:
+      name: Salt Error Code
 
     #Lifetime counters
     lifetime_runtime:
@@ -452,6 +464,10 @@ text_sensor:
   - platform: iq2020
     versionstr:
       name: Version
+    salt_module_status:
+      name: Salt Module Status
+    salt_level_friendly:
+      name: Salt Level Friendly
   - platform: template
     id: total_runtime_$device
     name: "Total Runtime_$device"
@@ -594,7 +610,4 @@ text_sensor:
 ![image](https://github.com/Ylianst/ESP-IQ2020/assets/1319013/c5b25972-1409-4477-964a-1dc21645407e)
 
 ![image](https://github.com/Ylianst/ESP-IQ2020/assets/1319013/1561b409-8329-48f7-a581-f6841265b1d5)
-
-
-
 

--- a/documentation/freshwater-salt-module-protocol.md
+++ b/documentation/freshwater-salt-module-protocol.md
@@ -1,0 +1,138 @@
+# Salt Module Protocol Guide (IQ2020)
+
+This document is the implementation guide for the **Freshwater salt module** on the IQ2020 RS485 bus.
+
+## Scope
+
+- Salt module address: `0x29`
+- Controller address: `0x01`
+- Message directions:
+  - Notification: `01 29 80` (salt module -> controller)
+  - Request: `29 01 40` (controller -> salt module)
+
+## Frame Formats
+
+### Notification Payload (`01 29 80`)
+
+```text
+1E 01 [PP] [CA] [SS] [CB] [MM] [MF] [EH] [EL] [GC] 00 00 69 [ST]
+```
+
+#### Notification Byte Definitions
+
+| Byte | Field | Typical Value(s) | Description |
+|---|---|---|---|
+| 1 | `HDR` | `0x1E` | Fixed payload header |
+| 2 | `CMD` | `0x01` | Fixed command type |
+| 3 | `PP` | `0x03..0x05` | Production level (system-config dependent) |
+| 4 | `CA` | `0x00..0xFF` | Cartridge age counter (days) |
+| 5 | `SS` | `0x00..0x78` | Salt level value (0..120 display scale) |
+| 6 | `CB` | `0x00..0xFF` | Cartridge age mirror (same as `CA`) |
+| 7 | `MM` | varies | Mode/state byte |
+| 8 | `MF` | `0x03,0x07,0x0A,0x0B,...` | Mode flag / panel state context |
+| 9 | `EH` | `0x00..0xFF` | Error code high byte |
+| 10 | `EL` | `0x00..0xFF` | Error code low byte |
+| 11 | `GC` | `0x00..0xFF` | Generation-hours counter |
+| 12 | — | `0x00` | Reserved |
+| 13 | — | `0x00` | Reserved |
+| 14 | — | `0x69` | Fixed marker byte |
+| 15 | `ST` | `0x41,0x81,0x01,...` | Status flags |
+
+### Request Payload (`29 01 40`)
+
+```text
+1E 01 [PL] [PW] FF FF [BT] 00 [C0] [C1] [C2] [C3] FF FF FF
+```
+
+#### Request Byte Definitions
+
+| Byte | Field | Typical Value(s) | Description |
+|---|---|---|---|
+| 1 | `HDR` | `0x1E` | Fixed payload header |
+| 2 | `CMD` | `0x01` | Fixed command type |
+| 3 | `PL` | `0x01..0x0A`, `0xFF` | Production level or `0xFF` for no-change |
+| 4 | `PW` | `0x02` | Keep fixed at `0x02` |
+| 5 | — | `0xFF` | Fixed |
+| 6 | — | `0xFF` | Fixed |
+| 7 | `BT` | `0xFF`, `0x01`, `0x02` | Boost trigger: none/on/off |
+| 8 | — | `0x00` | Fixed |
+| 9 | `C0` | varies | Command code byte 0 |
+| 10 | `C1` | varies | Command code byte 1 |
+| 11 | `C2` | varies | Command code byte 2 |
+| 12 | `C3` | varies | Command code byte 3 |
+| 13 | — | `0xFF` | Fixed |
+| 14 | — | `0xFF` | Fixed |
+| 15 | — | `0xFF` | Fixed |
+
+## Command Set
+
+Use these request payloads with header `29 01 40`.
+
+| Action | Request payload |
+|---|---|
+| Standard poll | `1E 01 FF 02 FF FF FF 00 FF 01 FF FF FF FF FF` |
+| Set production level (`PL=1..10` in component) | `1E 01 [PL] 02 FF FF FF 00 FF 01 FF FF FF FF FF` |
+| Boost ON | `1E 01 FF 02 FF FF 01 00 FF 01 FF FF FF FF FF` |
+| Boost OFF | `1E 01 FF 02 FF FF 02 00 FF 01 FF FF FF FF FF` |
+| Salt test | `1E 01 FF 02 FF FF FF 00 FF 01 FF 01 FF FF FF` |
+| Reset cartridge age | `1E 01 FF 02 FF FF FF 00 02 01 02 FF FF FF FF` |
+
+Safety baseline:
+
+- Keep all fixed bytes unchanged.
+- Only vary `PL`, `BT`, and `C0..C3` for supported actions.
+
+## Sensor and Entity Mapping
+
+This section maps protocol fields to entities in `components/iq2020`.
+
+- `salt_content` sensor: from notification byte 5 (`SS`)
+  - Freshwater (`0x29`): raw byte value
+  - ACE legacy compatibility (`0x24`): value is decoded differently in component logic
+- `salt_cartridge_age_days`: notification byte 4 (`CA`)
+- `salt_generation_hours`: notification byte 11 (`GC`)
+- `salt_error_code`: `(EH << 8) | EL` from bytes 9 and 10
+- `salt_module_status` text sensor:
+  - `idle` when `ST bit6` is set
+  - `generating_chlorine` when `ST bit7` is set and idle is not set
+  - `cleaning_cartridge` otherwise
+- `salt_level_friendly` text sensor from `SS` zones:
+  - `<24`: `red-low`
+  - `<36`: `yellow-low`
+  - `<84`: `green`
+  - `<96`: `yellow-high`
+  - `>=96`: `red-high`
+
+## Salt Level Scale
+
+`SS` is a 0..120 display scale.
+
+Operational zone guidance used by the component:
+
+- `0..23`: red-low
+- `24..35`: yellow-low
+- `36..83`: green
+- `84..95`: yellow-high
+- `96..120`: red-high
+
+Approximate ppm conversion used for interpretation (**just a guess**):
+
+- ~`20.83 ppm` per display unit
+- Example: `SS=84` -> ~`1750 ppm`
+
+## Status and Mode Notes
+
+- Boost state is represented through request trigger `BT` and observed response mode flags.
+- `ST` bit usage:
+  - bit 6 (`0x40`): idle indicator
+  - bit 7 (`0x80`): active polarity/status bit used in active states
+- `MM`/`MF` encode operation phases; for control logic, use the documented command triggers and stable outputs above.
+
+## Compatibility Note (ACE vs Freshwater)
+
+A spa will have either:
+
+- Legacy ACE path (`0x24`), or
+- Freshwater salt module (`0x29`)
+
+The main `components/iq2020` implementation supports both by branching behavior where needed. New advanced entities and command semantics in this guide are targeted at the Freshwater (`0x29`) protocol.


### PR DESCRIPTION
## What’s included

1. Salt level handling fixes
- Corrected `salt_content` to publish the true salt level value from the salt response payload
- Kept a single numeric salt level sensor (`salt_content`) to avoid duplication.

2. New salt telemetry sensors
- Added `salt_cartridge_age_days` (cartridge age counter).
- Added `salt_generation_hours` (chlorine generation hour counter).
- Added `salt_error_code` (combined 16-bit error code from EH/EL bytes).

3. New salt text sensors
- Added `salt_module_status`:
  - `generating_chlorine`
  - `cleaning_cartridge`
  - `idle`
- Added `salt_level_friendly`:
  - `red-low`, `yellow-low`, `green`, `yellow-high`, `red-high`

4. Boost command fix
- Updated boost ON/OFF behavior to use documented trigger semantics for salt-module (`BT=0x01` ON, `BT=0x02` OFF).

5. Salt control slider behavior
- Updated salt production level handling to allow `1..10`.
- Ensured receive-side validation and send-side guard both match this range.

6. New button actions
- Added `iq2020` button platform support with:
  - `Salt Test` command
  - `Reset Salt Cartridge` command

7. Compatibility handling
- Added module-address tracking so command paths can use the correct format depending on detected salt module address (`0x29` freshwater salt vs legacy `0x24` behavior).
- Kept ACE emulation logic intact.

8. Documentation updates
- Updated `documentation/configuration.md` with examples for:
  - New salt sensors/text sensors
  - New salt buttons
  - Salt level naming/usage updates
- Added `documentation/freshwater-salt-module-protocol.md` that documents everything known about the freshwater salt module.