### PR TITLE
Fix build on esphome 2026.7.0 (get_use_address removed)

### DIFF
--- a/components/iq2020/iq2020.cpp
+++ b/components/iq2020/iq2020.cpp
@@ -170,7 +170,12 @@ void IQ2020Component::loop() {
 
 void IQ2020Component::dump_config() {
 	ESP_LOGCONFIG(TAG, "IQ2020:");
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 7, 0)
+	char use_address_buf[esphome::network::USE_ADDRESS_BUFFER_SIZE];
+	ESP_LOGCONFIG(TAG, "  Address: %s:%u", esphome::network::get_use_address_to(use_address_buf), this->port_);
+#else
 	ESP_LOGCONFIG(TAG, "  Address: %s:%u", esphome::network::get_use_address(), this->port_);
+#endif
 	if (this->flow_control_pin_ != nullptr) {
 		ESP_LOGCONFIG(TAG, "  Flow Control Pin: ", this->flow_control_pin_);
 	}


### PR DESCRIPTION
esphome 2026.7.0 removed `network::get_use_address()` in favor of the buffer-based `get_use_address_to(std::span<char, USE_ADDRESS_BUFFER_SIZE>)`, so the current code fails to compile on 2026.7.0:

```
error: 'get_use_address' is not a member of 'esphome::network'; did you mean 'get_use_address_to'?
```

This guards the `dump_config()` address log line by `ESPHOME_VERSION_CODE` so it builds on 2026.7.0 while remaining compatible with older esphome. Same pattern already used by tube0013/esphome-components.

Tested: compiles on esphome 2026.7.0 and 2026.6.4.